### PR TITLE
Don't warn about custom user model if correctly using mixin.

### DIFF
--- a/hijack_admin/checks.py
+++ b/hijack_admin/checks.py
@@ -2,8 +2,16 @@
 from django.core.checks import Error, Warning, register
 from django.conf.global_settings import AUTH_USER_MODEL as DEFAULT_AUTH_USER_MODEL
 from django.conf import settings
+from django.contrib.admin.sites import site
+from django.contrib.auth import get_user_model
 
 from hijack import settings as hijack_settings
+from hijack_admin.admin import HijackUserAdminMixin
+
+
+def _using_hijack_admin_mixin():
+    user_admin_class = type(site._registry[get_user_model()])
+    return issubclass(user_admin_class, HijackUserAdminMixin)
 
 
 def check_get_requests_allowed(app_configs, **kwargs):
@@ -22,7 +30,8 @@ def check_get_requests_allowed(app_configs, **kwargs):
 
 def check_custom_user_model(app_configs, **kwargs):
     warnings = []
-    if settings.AUTH_USER_MODEL != DEFAULT_AUTH_USER_MODEL:
+    if (settings.AUTH_USER_MODEL != DEFAULT_AUTH_USER_MODEL and
+            not _using_hijack_admin_mixin()):
         warnings.append(
             Warning(
                 'django-hijack-admin does not work out the box with a custom user model.',

--- a/hijack_admin/tests/test_app/models.py
+++ b/hijack_admin/tests/test_app/models.py
@@ -1,0 +1,5 @@
+from django.db import models
+
+
+class BasicModel(models.Model):
+    pass

--- a/hijack_admin/tests/test_checks.py
+++ b/hijack_admin/tests/test_checks.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
+from compat import get_user_model
 import django
+from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
+from hijack_admin.admin import HijackUserAdmin
+from hijack_admin.tests.test_app.models import BasicModel
 from hijack.tests.utils import SettingsOverride
 
 if django.VERSION < (1, 7):
@@ -7,7 +12,7 @@ if django.VERSION < (1, 7):
 else:
     from django.conf import settings
     from django.core.checks import Error, Warning
-    from django.test import TestCase
+    from django.test import TestCase, override_settings
 
     from hijack import settings as hijack_settings
 
@@ -35,18 +40,36 @@ else:
                 ]
                 self.assertEqual(errors, expected_errors)
 
-        def test_check_custom_user_model(self):
+        def test_check_default_user_model(self):
             warnings = checks.check_custom_user_model(HijackAdminConfig)
             self.assertFalse(warnings)
 
-            with self.settings(AUTH_USER_MODEL='my_auth_user_model'):
-                warnings = checks.check_custom_user_model(HijackAdminConfig)
-                expected_warnings = [
-                    Warning(
-                        'django-hijack-admin does not work out the box with a custom user model.',
-                        hint='Please mix HijackUserAdminMixin into your custom UserAdmin.',
-                        obj=settings.AUTH_USER_MODEL,
-                        id='hijack_admin.W001',
-                    )
-                ]
-                self.assertEqual(warnings, expected_warnings)
+        @override_settings(AUTH_USER_MODEL='test_app.BasicModel')
+        def test_check_custom_user_model(self):
+            # Django doesn't re-register admins when using `override_settings`,
+            # so we have to do it manually in this test case.
+            admin.site.register(get_user_model(), HijackUserAdmin)
+
+            warnings = checks.check_custom_user_model(HijackAdminConfig)
+            self.assertFalse(warnings)
+
+            admin.site.unregister(get_user_model())
+
+        @override_settings(AUTH_USER_MODEL='test_app.BasicModel')
+        def test_check_custom_user_model_default_admin(self):
+            # Django doesn't re-register admins when using `override_settings`,
+            # so we have to do it manually in this test case.
+            admin.site.register(get_user_model(), UserAdmin)
+
+            warnings = checks.check_custom_user_model(HijackAdminConfig)
+            expected_warnings = [
+                Warning(
+                    'django-hijack-admin does not work out the box with a custom user model.',
+                    hint='Please mix HijackUserAdminMixin into your custom UserAdmin.',
+                    obj=settings.AUTH_USER_MODEL,
+                    id='hijack_admin.W001',
+                )
+            ]
+            self.assertEqual(warnings, expected_warnings)
+
+            admin.site.unregister(get_user_model())


### PR DESCRIPTION
Fixes https://github.com/arteria/django-hijack-admin/issues/2.