### PR TITLE
Using get to pull model name from dict

### DIFF
--- a/hijack_admin/checks.py
+++ b/hijack_admin/checks.py
@@ -10,7 +10,7 @@ from hijack_admin.admin import HijackUserAdminMixin
 
 
 def _using_hijack_admin_mixin():
-    user_admin_class = type(site._registry[get_user_model()])
+    user_admin_class = type(site._registry.get(get_user_model(), None))
     return issubclass(user_admin_class, HijackUserAdminMixin)
 
 


### PR DESCRIPTION
If the check does not see the user model in the dict it crashes rather than raises the warning/error as intended.