### PR TITLE
Add link and badge to PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Django admin integration for Django Hijack (https://github.com/arteria/django-hi
 
 [![Build Status](https://travis-ci.org/arteria/django-hijack-admin.svg?branch=master)](https://travis-ci.org/arteria/django-hijack-admin)
 [![Coverage Status](https://coveralls.io/repos/arteria/django-hijack-admin/badge.svg?branch=master&service=github)](https://coveralls.io/github/arteria/django-hijack-admin?branch=master)
+[![PyPI](https://img.shields.io/pypi/v/django-hijack-admin.svg)](https://pypi.python.org/pypi/django-hijack-admin)
 
 ![Screenshot of django-hijack in action on the admin site.](docs/admin-screenshot.png)
 


### PR DESCRIPTION
This is useful to be able to quickly check these things:

- Whether this package has been released on PyPI or not
- Which version number is the latest on PyPI
- Once you click on the link, you can verify what the PyPI package name is, for use with `pip`