### PR TITLE
Import reverse from compat

### DIFF
--- a/hijack_admin/admin.py
+++ b/hijack_admin/admin.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-from compat import get_user_model
+from compat import get_user_model, reverse
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
-from django.core.urlresolvers import reverse
 from django.template.loader import get_template
 from django.utils.translation import ugettext_lazy as _
 from django import VERSION


### PR DESCRIPTION
I fixed this RemovedInDjango20Warning. Could you review this when you have time? Thanx!!

> RemovedInDjango20Warning: Importing from django.core.urlresolvers is deprecated in favor of django.urls.