### PR TITLE
Fix django deprecation warning about use of `allow_tag` in admin

### DIFF
--- a/hijack_admin/admin.py
+++ b/hijack_admin/admin.py
@@ -3,6 +3,7 @@ from compat import get_user_model
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.template.loader import get_template
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 from django import VERSION
 
@@ -38,9 +39,8 @@ class HijackUserAdminMixin(object):
         if VERSION < (1, 8):
             button_context = Context(button_context)
 
-        return button_template.render(button_context)
+        return mark_safe(button_template.render(button_context))
 
-    hijack_field.allow_tags = True
     hijack_field.short_description = _('Hijack user')
 
 

--- a/hijack_admin/admin.py
+++ b/hijack_admin/admin.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 from compat import get_user_model
+from django import VERSION
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.template.loader import get_template
-from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
-from django import VERSION
-
 from hijack import settings as hijack_settings
+
 from hijack_admin import settings as hijack_admin_settings
 
 try:
@@ -39,7 +38,7 @@ class HijackUserAdminMixin(object):
         if VERSION < (1, 8):
             button_context = Context(button_context)
 
-        return mark_safe(button_template.render(button_context))
+        return button_template.render(button_context)
 
     hijack_field.short_description = _('Hijack user')
 

--- a/hijack_admin/tests/test_hijack_admin.py
+++ b/hijack_admin/tests/test_hijack_admin.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-
 from hijack.tests.test_hijack import BaseHijackTests
-from hijack.tests.utils import SettingsOverride
 
 from hijack_admin import settings as hijack_admin_settings
 from hijack_admin.tests.test_app.models import RelatedModel


### PR DESCRIPTION
The warning reads like this:

RemovedInDjango20Warning: Deprecated allow_tags attribute used on field hijack_field. Use django.utils.html.format_html(), format_html_join(), or django.utils.safestring.mark_safe() instead