### PR TITLE
Update django classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,8 @@ setup(name="django-hijack-admin",
                    'Framework :: Django :: 1.8',
                    'Framework :: Django :: 1.9',
                    'Framework :: Django :: 1.10',
+                   'Framework :: Django :: 1.11',
+                   'Framework :: Django :: 2.0',
                    'Programming Language :: Python',
                    'Programming Language :: Python :: 2',
                    'Programming Language :: Python :: 3', ], )


### PR DESCRIPTION
Add 1.11 and 2.0 to match with those tested in tox.ini

I just realized that https://github.com/arteria/django-hijack also tests on django 2.1, do we want to add that here too?