### PR TITLE
Modify related admin mixin to allow for custom field name for user in place of default 'user' field name

### DIFF
--- a/hijack_admin/admin.py
+++ b/hijack_admin/admin.py
@@ -42,7 +42,12 @@ class HijackUserAdminMixin(object):
 class HijackRelatedAdminMixin(HijackUserAdminMixin):
 
     def hijack_field(self, obj):
-        return super(HijackRelatedAdminMixin, self).hijack_field(obj.user)
+        user = getattr(obj, 'user', '')
+        if not user:
+            for field in obj._meta.get_fields():
+                if (field.one_to_one or field.many_to_one) and getattr(field, 'related_model') == get_user_model():
+                    user = getattr(obj, field.name)
+        return super(HijackRelatedAdminMixin, self).hijack_field(user)
 
 
 class HijackUserAdmin(HijackUserAdminMixin, UserAdmin):


### PR DESCRIPTION
The related mixin currently only works if the model field name in the related object is "user." This works in many cases, but in some cases, the related field name may have been changed to something different.
This change checks first to see if "user" is being used. If not, it checks the other fields to see if there is another field that maps to the user model that can be used as the hijack field.