### PR TITLE
Resolve Django 3.0 deprecation warning

### DIFF
--- a/hijack_admin/admin.py
+++ b/hijack_admin/admin.py
@@ -4,7 +4,7 @@ from django import VERSION
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.template.loader import get_template
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from hijack import settings as hijack_settings
 


### PR DESCRIPTION
Replacing `ugettext_lazy` method with `gettext_lazy`. They are aliases, so there should be no issue switching away from the deprecated version.

Fixes #35 